### PR TITLE
tokyo olympics 2021 dataset added

### DIFF
--- a/misc.txt
+++ b/misc.txt
@@ -1,3 +1,5 @@
 https://github.com/fivethirtyeight/data.  This news outlet, started by Nate Silver, focuses on data-driven stories, often about sports and politics. Many of the datasets underlying their stories are online on GitHub.
 
 https://toolbox.google.com/datasetsearch.  This search tool is in Beta, but it provides high quality results integrated with Google Scholar, such that you can see how many papers cite a given dataset.
+
+https://www.kaggle.com/arjunprasadsarkhel/2021-olympics-in-tokyo?select=Medals.xlsx This contains a data set about the tokyo 2021 olympics.


### PR DESCRIPTION
The link I added refers to multiple datasets that can be installed. This is the description provided on the website kaggle:

"Details
This contains the details of over 11,000 athletes, with 47 disciplines, along with 743 Teams taking part in the 2021(2020) Tokyo Olympics.
This dataset contains the details of the Athletes, Coaches, Teams participating as well as the Entries by gender. It contains their names, countries represented, discipline, gender of competitors, name of the coaches.

Will update the dataset with medals(gold, silver, bronze), more details about the athletes after few weeks.

Credits
Source: Tokyo Olympics 2020 Website"